### PR TITLE
refactor: ingest pipeline

### DIFF
--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -25,16 +25,22 @@ struct ServerState {
     ingest: PersistHandle,
 }
 
+impl ServerState {
+    pub fn new(max_events: i64) -> Self {
+        Self {
+            ingest: PersistHandle::new(max_events),
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let events_before_persist: i64 = std::env::var("LYNX_PERSIST_EVENTS")
         .unwrap_or("2".to_string())
         .parse()
         .unwrap();
-    let persist_handle = PersistHandle::new(events_before_persist);
-    let state = ServerState {
-        ingest: persist_handle,
-    };
+
+    let state = ServerState::new(events_before_persist);
 
     let app = Router::new()
         .route("/health", get(health))

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -1,8 +1,3 @@
-use std::{collections::HashMap, sync::Arc};
-
-use arrow::array::{
-    ArrayRef, RecordBatch, StringBuilder, TimestampMicrosecondBuilder, UInt64Builder,
-};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -10,15 +5,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use parquet::arrow::ArrowWriter;
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum Precision {
-    Nanosecond,
-    Microsecond,
-}
+use lynx::{event::Event, persist::PersistHandle};
 
 /// The level of persistence to run the server in, this dictates how ingested
 /// events are persisted.
@@ -33,91 +20,21 @@ enum Persistence {
     Remote, // TODO
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Event {
-    /// Namespace where data should be written.
-    namespace: String,
-    /// Name of the event which is being recorded.
-    name: String,
-    /// Timestamp that the event occurred.
-    timestamp: i64,
-    /// Optional precision of the provided timestamp. When this is not provided,
-    /// nanosecond precision is assumed.
-    precision: Option<Precision>,
-    /// Value associated with the event.
-    value: i64,
-    /// Arbitrary key-value metadata associated with the event.
-    metadata: serde_json::Value,
-}
-
 #[derive(Debug, Clone)]
 struct ServerState {
-    ingest: tokio::sync::mpsc::Sender<Event>,
+    ingest: PersistHandle,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
-
-    let state = ServerState { ingest: tx };
-
-    tokio::spawn(async move {
-        let events_before_persist: i64 = std::env::var("LYNX_PERSIST_EVENTS")
-            .unwrap_or("2".to_string())
-            .parse()
-            .unwrap();
-        let mut mem_events: HashMap<String, Vec<Event>> = HashMap::new();
-        loop {
-            if let Some(event) = rx.recv().await {
-                println!("{event:?}");
-                let in_mem_event = mem_events
-                    .entry(event.namespace.clone())
-                    .and_modify(|f| f.push(event.clone()))
-                    .or_default();
-
-                if in_mem_event.len() == events_before_persist as usize {
-                    println!("Persisting events for {}", event.namespace);
-                    for (namespace, events) in &mem_events {
-                        let path = format!("/tmp/lynx/{namespace}");
-
-                        if !std::fs::exists(&path).unwrap() {
-                            std::fs::create_dir_all(&path).unwrap();
-                        }
-
-                        let now = chrono::Utc::now().timestamp_micros();
-                        let filename = format!("lynx-{now}.parquet");
-                        let file = std::fs::File::create_new(format!("{path}/{filename}")).unwrap();
-                        let mut names = StringBuilder::new();
-                        let mut values = UInt64Builder::new();
-                        // TODO: precision hints
-                        let mut timestamps = TimestampMicrosecondBuilder::new();
-
-                        for event in events {
-                            names.append_value(&event.name);
-                            values.append_value(event.value as u64);
-                            timestamps.append_value(event.timestamp);
-                        }
-
-                        let names = Arc::new(names.finish()) as ArrayRef;
-                        let values = Arc::new(values.finish()) as ArrayRef;
-                        let timestamps = Arc::new(timestamps.finish()) as ArrayRef;
-
-                        let batch = RecordBatch::try_from_iter(vec![
-                            ("timestamp", timestamps),
-                            ("name", names),
-                            ("value", values),
-                        ])
-                        .unwrap();
-
-                        let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
-                        writer.write(&batch).unwrap();
-                        writer.close().unwrap();
-                    }
-                    mem_events.clear();
-                }
-            }
-        }
-    });
+    let events_before_persist: i64 = std::env::var("LYNX_PERSIST_EVENTS")
+        .unwrap_or("2".to_string())
+        .parse()
+        .unwrap();
+    let persist_handle = PersistHandle::new(events_before_persist);
+    let state = ServerState {
+        ingest: persist_handle,
+    };
 
     let app = Router::new()
         .route("/health", get(health))
@@ -134,8 +51,11 @@ async fn health() -> &'static str {
     "OK"
 }
 
-async fn ingest(State(state): State<ServerState>, Json(event): Json<Event>) -> impl IntoResponse {
-    state.ingest.send(event).await.unwrap();
+async fn ingest(
+    State(mut state): State<ServerState>,
+    Json(event): Json<Event>,
+) -> impl IntoResponse {
+    state.ingest.handle_event(event).await;
 
     StatusCode::CREATED
 }

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -13,7 +13,7 @@ use axum::{
 use parquet::arrow::ArrowWriter;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum Precision {
     Nanosecond,
@@ -33,7 +33,7 @@ enum Persistence {
     Remote, // TODO
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Event {
     /// Namespace where data should be written.
     namespace: String,
@@ -60,8 +60,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
 
     let state = ServerState { ingest: tx };
-    // In-memory tracker for persisted files.
-    let mut persisted_files = Vec::new();
 
     tokio::spawn(async move {
         let events_before_persist: i64 = std::env::var("LYNX_PERSIST_EVENTS")
@@ -69,17 +67,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .parse()
             .unwrap();
         let mut mem_events: HashMap<String, Vec<Event>> = HashMap::new();
-        let mut events_recv = 0;
         loop {
             if let Some(event) = rx.recv().await {
                 println!("{event:?}");
-                mem_events
+                let in_mem_event = mem_events
                     .entry(event.namespace.clone())
-                    .and_modify(|f| f.push(event))
+                    .and_modify(|f| f.push(event.clone()))
                     .or_default();
-                events_recv += 1;
-                if events_recv == events_before_persist {
-                    println!("Persisting events");
+
+                if in_mem_event.len() == events_before_persist as usize {
+                    println!("Persisting events for {}", event.namespace);
                     for (namespace, events) in &mem_events {
                         let path = format!("/tmp/lynx/{namespace}");
 
@@ -115,9 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
                         writer.write(&batch).unwrap();
                         writer.close().unwrap();
-                        persisted_files.push(filename);
                     }
-                    events_recv = 0;
                     mem_events.clear();
                 }
             }

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -1,6 +1,8 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use arrow::array::{ArrayRef, RecordBatch, StringBuilder, TimestampMicrosecondBuilder, UInt64Builder};
+use arrow::array::{
+    ArrayRef, RecordBatch, StringBuilder, TimestampMicrosecondBuilder, UInt64Builder,
+};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -33,6 +35,8 @@ enum Persistence {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Event {
+    /// Namespace where data should be written.
+    namespace: String,
     /// Name of the event which is being recorded.
     name: String,
     /// Timestamp that the event occurred.
@@ -60,27 +64,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut persisted_files = Vec::new();
 
     tokio::spawn(async move {
-        let events_before_persist: i64 = std::env::var("LYNX_PERSIST_EVENTS").unwrap_or("2".to_string()).parse().unwrap();
-        let mut events_buf = Vec::new();
+        let events_before_persist: i64 = std::env::var("LYNX_PERSIST_EVENTS")
+            .unwrap_or("2".to_string())
+            .parse()
+            .unwrap();
+        let mut mem_events: HashMap<String, Vec<Event>> = HashMap::new();
         let mut events_recv = 0;
         loop {
-            match rx.recv().await {
-                Some(event) => {
-                    println!("{event:?}");
-                    events_buf.push(event);
-                    events_recv += 1;
-                    if events_recv == events_before_persist {
-                        println!("Persisting events");
+            if let Some(event) = rx.recv().await {
+                println!("{event:?}");
+                mem_events
+                    .entry(event.namespace.clone())
+                    .and_modify(|f| f.push(event))
+                    .or_default();
+                events_recv += 1;
+                if events_recv == events_before_persist {
+                    println!("Persisting events");
+                    for (namespace, events) in &mem_events {
+                        let path = format!("/tmp/lynx/{namespace}");
+
+                        if !std::fs::exists(&path).unwrap() {
+                            std::fs::create_dir_all(&path).unwrap();
+                        }
+
                         let now = chrono::Utc::now().timestamp_micros();
                         let filename = format!("lynx-{now}.parquet");
-                        let file = std::fs::File::create_new(&filename).unwrap();
-
+                        let file = std::fs::File::create_new(format!("{path}/{filename}")).unwrap();
                         let mut names = StringBuilder::new();
                         let mut values = UInt64Builder::new();
                         // TODO: precision hints
                         let mut timestamps = TimestampMicrosecondBuilder::new();
 
-                        for event in &events_buf {
+                        for event in events {
                             names.append_value(&event.name);
                             values.append_value(event.value as u64);
                             timestamps.append_value(event.timestamp);
@@ -90,16 +105,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let values = Arc::new(values.finish()) as ArrayRef;
                         let timestamps = Arc::new(timestamps.finish()) as ArrayRef;
 
-                        let batch = RecordBatch::try_from_iter(vec![("timestamp", timestamps), ("name", names), ("value", values)]).unwrap();
+                        let batch = RecordBatch::try_from_iter(vec![
+                            ("timestamp", timestamps),
+                            ("name", names),
+                            ("value", values),
+                        ])
+                        .unwrap();
+
                         let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
                         writer.write(&batch).unwrap();
                         writer.close().unwrap();
                         persisted_files.push(filename);
-                        events_recv = 0;
-                        events_buf.clear();
                     }
-                },
-                None => {}
+                    events_recv = 0;
+                    mem_events.clear();
+                }
             }
         }
     });
@@ -109,8 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/v1/ingest", post(ingest))
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
-        .await?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
 
     axum::serve(listener, app).await?;
     Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    /// Namespace where data should be written.
+    pub namespace: String,
+    /// Name of the event which is being recorded.
+    pub name: String,
+    /// Timestamp that the event occurred.
+    pub timestamp: i64,
+    /// Optional precision of the provided timestamp. When this is not provided,
+    /// nanosecond precision is assumed.
+    pub precision: Option<Precision>,
+    /// Value associated with the event.
+    pub value: i64,
+    /// Arbitrary key-value metadata associated with the event.
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Precision {
+    Nanosecond,
+    Microsecond,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod event;
+pub mod persist;

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, RecordBatch, StringBuilder, TimestampMicrosecondBuilder, UInt64Builder,
+};
+use parquet::arrow::ArrowWriter;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::event::Event;
+
+#[derive(Debug, Clone)]
+pub struct PersistHandle {
+    events_queue: Sender<Event>,
+}
+
+impl PersistHandle {
+    pub fn new(max_events: i64) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        let actor = PersistActor::new(max_events, rx);
+        tokio::spawn(run_persist_actor(actor));
+
+        Self { events_queue: tx }
+    }
+
+    pub async fn handle_event(&mut self, event: Event) {
+        self.events_queue.send(event).await.unwrap();
+    }
+}
+
+pub struct PersistActor {
+    max_events: i64,
+    event_receiver: Receiver<Event>,
+}
+
+impl PersistActor {
+    pub fn new(max_events: i64, event_receiver: Receiver<Event>) -> Self {
+        Self {
+            max_events,
+            event_receiver,
+        }
+    }
+}
+
+pub async fn run_persist_actor(mut actor: PersistActor) {
+    let mut mem_events: HashMap<String, Vec<Event>> = HashMap::new();
+    while let Some(event) = actor.event_receiver.recv().await {
+        let in_mem_event = mem_events
+            .entry(event.namespace.clone())
+            .and_modify(|f| f.push(event.clone()))
+            .or_insert_with(|| vec![event.clone()]);
+
+        if in_mem_event.len() == actor.max_events as usize {
+            println!("Persisting events for {}", event.namespace);
+            for (namespace, events) in &mem_events {
+                let path = format!("/tmp/lynx/{namespace}");
+
+                if !std::fs::exists(&path).unwrap() {
+                    std::fs::create_dir_all(&path).unwrap();
+                }
+
+                let now = chrono::Utc::now().timestamp_micros();
+                let filename = format!("lynx-{now}.parquet");
+                let file = std::fs::File::create_new(format!("{path}/{filename}")).unwrap();
+                let mut names = StringBuilder::new();
+                let mut values = UInt64Builder::new();
+                // TODO: precision hints
+                let mut timestamps = TimestampMicrosecondBuilder::new();
+
+                for event in events {
+                    names.append_value(&event.name);
+                    values.append_value(event.value as u64);
+                    timestamps.append_value(event.timestamp);
+                }
+
+                let names = Arc::new(names.finish()) as ArrayRef;
+                let values = Arc::new(values.finish()) as ArrayRef;
+                let timestamps = Arc::new(timestamps.finish()) as ArrayRef;
+
+                let batch = RecordBatch::try_from_iter(vec![
+                    ("timestamp", timestamps),
+                    ("name", names),
+                    ("value", values),
+                ])
+                .unwrap();
+
+                let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+                writer.write(&batch).unwrap();
+                writer.close().unwrap();
+            }
+            mem_events.clear();
+        }
+    }
+}

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -31,11 +31,13 @@ impl PersistHandle {
 pub struct PersistActor {
     max_events: i64,
     event_receiver: Receiver<Event>,
+    events: HashMap<String, Vec<Event>>,
 }
 
 impl PersistActor {
     pub fn new(max_events: i64, event_receiver: Receiver<Event>) -> Self {
         Self {
+            events: HashMap::new(),
             max_events,
             event_receiver,
         }
@@ -43,16 +45,16 @@ impl PersistActor {
 }
 
 pub async fn run_persist_actor(mut actor: PersistActor) {
-    let mut mem_events: HashMap<String, Vec<Event>> = HashMap::new();
     while let Some(event) = actor.event_receiver.recv().await {
-        let in_mem_event = mem_events
+        let in_mem_event = actor
+            .events
             .entry(event.namespace.clone())
             .and_modify(|f| f.push(event.clone()))
             .or_insert_with(|| vec![event.clone()]);
 
         if in_mem_event.len() == actor.max_events as usize {
             println!("Persisting events for {}", event.namespace);
-            for (namespace, events) in &mem_events {
+            for (namespace, events) in &actor.events {
                 let path = format!("/tmp/lynx/{namespace}");
 
                 if !std::fs::exists(&path).unwrap() {
@@ -88,7 +90,7 @@ pub async fn run_persist_actor(mut actor: PersistActor) {
                 writer.write(&batch).unwrap();
                 writer.close().unwrap();
             }
-            mem_events.clear();
+            actor.events.clear();
         }
     }
 }

--- a/testdata/event.json
+++ b/testdata/event.json
@@ -1,4 +1,5 @@
 {
+    "namespace": "house",
     "name": "heater",
     "timestamp": 1734557462688037,
     "precision": "microsecond",


### PR DESCRIPTION
Ingest for incoming events need to be keyed by some identifier, a "namespace" is being used for this purpose.

This alters how the ingest parquet files are created by holding them in memory with a `HashMap`, rather than an arbitrary `Vec` of events and utilises the actor pattern with a `PersistHandle`.
