### PR TITLE
feat: http query response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,7 @@ name = "lynx"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "arrow-json",
  "axum",
  "chrono",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 arrow = "53.3.0"
+arrow-json = "53.3.0"
 axum = { version = "0.7.9", features = ["macros"] }
 chrono = "0.4.39"
 datafusion = "43.0.0"

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -112,9 +112,10 @@ struct InboundQuery {
 }
 
 async fn query(
+    headers: HeaderMap,
     State(state): State<ServerState>,
     Json(payload): Json<InboundQuery>,
-) -> impl IntoResponse {
+) -> (StatusCode, impl IntoResponse) {
     let namespace_path = &format!(
         "{}/lynx/{}",
         state.persist_path.to_string_lossy(),
@@ -123,9 +124,30 @@ async fn query(
     if let Some(record_batches) =
         handle_sql(state.files, &payload.namespace, payload.sql, namespace_path).await
     {
-        // TODO: remove the print at a later date.
-        let _ = print_batches(&record_batches);
-        (StatusCode::OK, "OK".to_string())
+        let format = match headers.get(LYNX_FORMAT_HEADER) {
+            Some(v) => String::from_utf8_lossy(v.as_bytes())
+                .to_string()
+                .as_str()
+                .into(),
+            None => QueryFormat::Json,
+        };
+
+        match format {
+            QueryFormat::Pretty => {
+                let output = pretty_format_batches(&record_batches).unwrap();
+                (StatusCode::OK, output.to_string())
+            }
+            QueryFormat::Json => {
+                let buf = Vec::new();
+                let mut w = arrow_json::ArrayWriter::new(buf);
+                for record in record_batches {
+                    w.write(&record).expect("Can write to buffer");
+                }
+                w.finish().expect("Can finalise buffer");
+                let json = String::from_utf8(w.into_inner()).expect("Valid JSON written");
+                (StatusCode::OK, json)
+            }
+        }
     } else {
         (
             StatusCode::NOT_FOUND,

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
-use arrow::util::pretty::print_batches;
+use arrow::util::pretty::pretty_format_batches;
+use axum::http::HeaderMap;
 use axum::{
     extract::State,
     http::StatusCode,
@@ -15,6 +16,8 @@ use tokio::sync::Mutex;
 
 use lynx::{event::Event, persist::PersistHandle, query::handle_sql};
 
+const LYNX_FORMAT_HEADER: &str = "X-Lynx-Format";
+
 /// The level of persistence to run the server in, this dictates how ingested
 /// events are persisted.
 ///
@@ -26,6 +29,23 @@ use lynx::{event::Event, persist::PersistHandle, query::handle_sql};
 enum Persistence {
     Local,
     Remote, // TODO
+}
+
+#[derive(Debug, Clone, Default)]
+enum QueryFormat {
+    #[default]
+    Json,
+    Pretty,
+}
+
+impl From<&str> for QueryFormat {
+    fn from(value: &str) -> Self {
+        match value {
+            "json" => QueryFormat::Json,
+            "pretty" => QueryFormat::Pretty,
+            _ => QueryFormat::Json, // Default to JSON
+        }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Closes https://github.com/jdockerty/lynx/issues/4

This adds the query response to be sent over the wire via HTTP, with 2 choices of formatting.

The default option is JSON (`QueryFormat::Json`), leveraging the `arrow_json` crate. The other option is a pretty format (`QueryFormat::Pretty`) which provides the same view that the previous `df.show()` did with a pretty print of the batches, providing a pretty table view of the query result.

This is controlled through the sent header of the query request, `x-lynx-format`.
