### PR TITLE
feat: use `object_store` within ingest path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "chrono",
  "clap",
  "datafusion",
+ "object_store",
  "parquet",
  "predicates",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ axum = { version = "0.7.9", features = ["macros"] }
 chrono = "0.4.39"
 clap = { version = "4.5.26", features = ["derive", "env"] }
 datafusion = "43.0.0"
+object_store = "0.11.2"
 parquet = "53.3.0"
 reqwest = "0.12.12"
 serde = { version = "1.0.216", features = ["derive"] }

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use clap::{Parser, Subcommand};
 use lynx::{
     query::QueryFormat,
-    server::{self, LYNX_FORMAT_HEADER, V1_INGEST_PATH, V1_QUERY_PATH},
+    server::{self, Persistence, LYNX_FORMAT_HEADER, V1_INGEST_PATH, V1_QUERY_PATH},
 };
 use reqwest::{header::CONTENT_TYPE, StatusCode};
 
@@ -30,6 +30,12 @@ enum Commands {
         /// Path where lynx will persist parquet files.
         #[arg(long, env = "LYNX_PERSIST_PATH", default_value = "/tmp")]
         persist_path: PathBuf,
+
+        /// Dictate where parquet files will be persisted.
+        ///
+        /// All modes except 'local' require extra configuration.
+        #[arg(long, env = "LYNX_PERSIST_MODE", default_value = "local")]
+        persist_mode: Persistence,
     },
     /// Write data to lynx
     Write {
@@ -70,8 +76,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             port,
             events_before_persist,
             persist_path,
+            persist_mode,
         } => {
-            server::run(&host, port, events_before_persist, persist_path.into()).await?;
+            let object_store = match persist_mode {
+                Persistence::Local => {
+                    object_store::local::LocalFileSystem::new_with_prefix(&persist_path)?
+                }
+                Persistence::S3 => todo!(),
+            };
+            server::run(
+                &host,
+                port,
+                events_before_persist,
+                persist_path,
+                Arc::new(object_store),
+            )
+            .await?;
         }
         Commands::Write { host, port, file } => {
             let json = std::fs::read(&file).unwrap();
@@ -86,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match resp.status() {
                 StatusCode::CREATED => {}
-                code @ _ => {
+                code => {
                     return Err(format!(
                         "received unexpected response {code}, body: {}",
                         resp.text().await.unwrap()

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -20,11 +20,11 @@ pub struct PersistHandle {
 }
 
 impl PersistHandle {
-    pub fn new(
+    pub fn new<O: ObjectStore>(
         files: Arc<Mutex<HashMap<String, SessionContext>>>,
         persist_path: PathBuf,
         max_events: i64,
-        object_store: Arc<dyn ObjectStore>,
+        object_store: Arc<O>,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
         let actor = PersistActor::new(max_events, rx, files, persist_path, object_store);
@@ -38,22 +38,22 @@ impl PersistHandle {
     }
 }
 
-pub struct PersistActor {
+pub struct PersistActor<O: ObjectStore> {
     max_events: i64,
     event_receiver: Receiver<Event>,
     events: HashMap<String, Vec<Event>>,
     files: Arc<Mutex<HashMap<String, SessionContext>>>,
     persist_path: PathBuf,
-    object_store: Arc<dyn ObjectStore>,
+    object_store: Arc<O>,
 }
 
-impl PersistActor {
+impl<O: ObjectStore> PersistActor<O> {
     pub fn new(
         max_events: i64,
         event_receiver: Receiver<Event>,
         files: Arc<Mutex<HashMap<String, SessionContext>>>,
         persist_path: PathBuf,
-        object_store: Arc<dyn ObjectStore>,
+        object_store: Arc<O>,
     ) -> Self {
         Self {
             files,
@@ -66,7 +66,7 @@ impl PersistActor {
     }
 }
 
-pub async fn run_persist_actor(mut actor: PersistActor) {
+pub async fn run_persist_actor<O: ObjectStore>(mut actor: PersistActor<O>) {
     while let Some(event) = actor.event_receiver.recv().await {
         let in_mem_event = actor
             .events

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -5,6 +5,7 @@ use arrow::array::{
     ArrayRef, RecordBatch, StringBuilder, TimestampMicrosecondBuilder, UInt64Builder,
 };
 use datafusion::execution::context::SessionContext;
+use object_store::{ObjectStore, PutPayload};
 use parquet::arrow::ArrowWriter;
 use tokio::sync::{
     mpsc::{Receiver, Sender},
@@ -23,9 +24,10 @@ impl PersistHandle {
         files: Arc<Mutex<HashMap<String, SessionContext>>>,
         persist_path: PathBuf,
         max_events: i64,
+        object_store: Arc<dyn ObjectStore>,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
-        let actor = PersistActor::new(max_events, rx, files, persist_path);
+        let actor = PersistActor::new(max_events, rx, files, persist_path, object_store);
         tokio::spawn(run_persist_actor(actor));
 
         Self { events_queue: tx }
@@ -42,6 +44,7 @@ pub struct PersistActor {
     events: HashMap<String, Vec<Event>>,
     files: Arc<Mutex<HashMap<String, SessionContext>>>,
     persist_path: PathBuf,
+    object_store: Arc<dyn ObjectStore>,
 }
 
 impl PersistActor {
@@ -50,6 +53,7 @@ impl PersistActor {
         event_receiver: Receiver<Event>,
         files: Arc<Mutex<HashMap<String, SessionContext>>>,
         persist_path: PathBuf,
+        object_store: Arc<dyn ObjectStore>,
     ) -> Self {
         Self {
             files,
@@ -57,6 +61,7 @@ impl PersistActor {
             max_events,
             event_receiver,
             persist_path,
+            object_store,
         }
     }
 }
@@ -72,16 +77,6 @@ pub async fn run_persist_actor(mut actor: PersistActor) {
         if in_mem_event.len() == actor.max_events as usize {
             eprintln!("Persisting events for {}", event.namespace);
             for (namespace, events) in &actor.events {
-                let path = format!("{}/lynx/{namespace}", actor.persist_path.to_string_lossy());
-                eprintln!("Persisting to {path}");
-
-                if !std::fs::exists(&path).unwrap() {
-                    std::fs::create_dir_all(&path).unwrap();
-                }
-
-                let now = chrono::Utc::now().timestamp_micros();
-                let filename = format!("lynx-{now}.parquet");
-                let file = std::fs::File::create_new(format!("{path}/{filename}")).unwrap();
                 let mut names = StringBuilder::new();
                 let mut values = UInt64Builder::new();
                 // TODO: precision hints
@@ -104,9 +99,19 @@ pub async fn run_persist_actor(mut actor: PersistActor) {
                 ])
                 .unwrap();
 
-                let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+                let mut v = Vec::new();
+                let mut writer = ArrowWriter::try_new(&mut v, batch.schema(), None).unwrap();
                 writer.write(&batch).unwrap();
                 writer.close().unwrap();
+
+                let now = chrono::Utc::now().timestamp_micros();
+                let filename = format!("lynx-{now}.parquet");
+                let path = object_store::path::Path::from(format!("lynx/{namespace}/{filename}"));
+                eprintln!("Persisting to {}/{path}", actor.persist_path.display());
+
+                let payload = PutPayload::from_bytes(v.into());
+                actor.object_store.put(&path, payload).await.unwrap();
+
                 actor
                     .files
                     .lock()
@@ -136,7 +141,14 @@ mod test {
         let (tx, rx) = tokio::sync::mpsc::channel(10);
         let temp_dir = TempDir::new().unwrap();
         let files = Arc::new(Mutex::new(HashMap::new()));
-        let actor = PersistActor::new(1, rx, Arc::clone(&files), temp_dir.path().to_path_buf());
+        let object_store = Arc::new(object_store::memory::InMemory::new());
+        let actor = PersistActor::new(
+            1,
+            rx,
+            Arc::clone(&files),
+            temp_dir.path().to_path_buf(),
+            object_store,
+        );
 
         let namespace = "my_org_1".to_string();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,11 +50,11 @@ struct ServerState {
 }
 
 impl ServerState {
-    pub fn new(
+    pub fn new<O: ObjectStore>(
         files: Arc<Mutex<HashMap<String, SessionContext>>>,
         max_events: i64,
         persist_path: PathBuf,
-        object_store: Arc<dyn ObjectStore>,
+        object_store: Arc<O>,
     ) -> Self {
         Self {
             files: Arc::clone(&files),
@@ -64,12 +64,12 @@ impl ServerState {
     }
 }
 
-pub async fn run(
+pub async fn run<O: ObjectStore>(
     host: &str,
     port: u16,
     events_before_persist: i64,
     persist_path: PathBuf,
-    object_store: Arc<dyn ObjectStore>,
+    object_store: Arc<O>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let files = Arc::new(Mutex::new(HashMap::new()));
     let state = ServerState::new(files, events_before_persist, persist_path, object_store);

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,9 +24,8 @@ pub const V1_INGEST_PATH: &str = "api/v1/ingest";
 /// The level of persistence to run the server in, this dictates how ingested
 /// events are persisted.
 ///
-/// - Local means that events are ingested and written to local parquet files.
-/// - S3 means that events are ingested and parquet files are written into
-///   an S3-compatible object store.
+/// - Local: parquet files will be persisted to the local filesystem.
+/// - S3: parquet files will be persisted to an S3-compatible object store.
 #[derive(Debug, Clone, Default, clap::ValueEnum)]
 pub enum Persistence {
     #[default]

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,15 @@ pub enum Persistence {
     S3,
 }
 
+impl Persistence {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::S3 => "s3",
+            Self::Local => "local",
+        }
+    }
+}
+
 #[derive(Clone)]
 struct ServerState {
     ingest: PersistHandle,

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,7 @@ use axum::{
     Json, Router,
 };
 use datafusion::prelude::SessionContext;
+use object_store::ObjectStore;
 use tokio::sync::Mutex;
 
 pub const LYNX_FORMAT_HEADER: &str = "X-Lynx-Format";
@@ -24,13 +25,13 @@ pub const V1_INGEST_PATH: &str = "api/v1/ingest";
 /// events are persisted.
 ///
 /// - Local means that events are ingested and written to local parquet files.
-/// - Remote means that events are ingested and parquet files are written into
-///   an object store implementation.
-#[derive(Debug)]
-#[allow(dead_code)]
-enum Persistence {
+/// - S3 means that events are ingested and parquet files are written into
+///   an S3-compatible object store.
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+pub enum Persistence {
+    #[default]
     Local,
-    Remote, // TODO
+    S3,
 }
 
 #[derive(Clone)]
@@ -45,11 +46,12 @@ impl ServerState {
         files: Arc<Mutex<HashMap<String, SessionContext>>>,
         max_events: i64,
         persist_path: PathBuf,
+        object_store: Arc<dyn ObjectStore>,
     ) -> Self {
         Self {
             files: Arc::clone(&files),
             persist_path: persist_path.clone(),
-            ingest: PersistHandle::new(files, persist_path, max_events),
+            ingest: PersistHandle::new(files, persist_path, max_events, object_store),
         }
     }
 }
@@ -59,9 +61,10 @@ pub async fn run(
     port: u16,
     events_before_persist: i64,
     persist_path: PathBuf,
+    object_store: Arc<dyn ObjectStore>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let files = Arc::new(Mutex::new(HashMap::new()));
-    let state = ServerState::new(files, events_before_persist, persist_path);
+    let state = ServerState::new(files, events_before_persist, persist_path, object_store);
 
     let app = Router::new()
         .route("/health", get(health))

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -212,6 +212,7 @@ async fn persist_with_increased_counter() {
     lynx.ingest(&event).await;
     lynx.ingest(&event).await;
     lynx.ingest(&event).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert!(
         std::fs::exists(&namespace_path).unwrap(),
         "Expected persist after 5 events"

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,135 +1,13 @@
-#![expect(dead_code)]
-
 use std::{process::Command, time::Duration};
 
 use assert_cmd::{assert::OutputAssertExt, cargo::CommandCargoExt, output::OutputOkExt};
-use lynx::{
-    event::Event,
-    query::{InboundQuery, QueryFormat, QueryResponse},
-    server::{Persistence, V1_INGEST_PATH, V1_QUERY_PATH},
-    LYNX_FORMAT_HEADER,
-};
+use lynx::query::{InboundQuery, QueryFormat, QueryResponse};
 use predicates::{boolean::PredicateBooleanExt, str::contains};
-use rand::Rng;
-use reqwest::{header::CONTENT_TYPE, StatusCode};
-use tempfile::{NamedTempFile, TempDir};
+use tempfile::NamedTempFile;
 
 mod helpers;
 
-struct Lynx {
-    process: std::process::Child,
-    client: reqwest::Client,
-    port: u16,
-    persist_path: TempDir,
-    /// Options that the test instance of lynx was configured with.
-    options: LynxOptions,
-}
-
-#[derive(Default)]
-struct LynxOptions {
-    port: Option<u16>,
-    max_events: Option<i64>,
-    persist_mode: Option<Persistence>,
-}
-
-impl LynxOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_max_events(mut self, max_events: i64) -> Self {
-        self.max_events = Some(max_events);
-        self
-    }
-
-    pub fn with_port(mut self, port: u16) -> Self {
-        self.port = Some(port);
-        self
-    }
-
-    pub fn with_persist_mode(mut self, persist_mode: Persistence) -> Self {
-        self.persist_mode = Some(persist_mode);
-        self
-    }
-}
-
-impl Lynx {
-    pub fn new(opts: LynxOptions) -> Self {
-        let persist_path = TempDir::new().unwrap();
-
-        let port = opts.port.unwrap_or_else(|| {
-            let mut rand = rand::thread_rng();
-            rand.gen_range(1024..=65535) // User port range
-        });
-
-        let max_events = opts.max_events.unwrap_or(2);
-        let persist_mode = opts.persist_mode.clone().unwrap_or_default();
-
-        let process = Command::cargo_bin(env!("CARGO_PKG_NAME"))
-            .unwrap()
-            .arg("server")
-            .env("LYNX_PORT", port.to_string())
-            .env("LYNX_PERSIST_PATH", persist_path.path())
-            .env("LYNX_PERSIST_EVENTS", max_events.to_string())
-            .env("LYNX_PERSIST_MODE", persist_mode.as_str())
-            .spawn()
-            .expect("Can run lynx");
-
-        // Arbitrary sleep to enforce server startup period
-        // TODO: this could be flakey
-        std::thread::sleep(Duration::from_secs(2));
-
-        Self {
-            port,
-            persist_path,
-            process,
-            client: reqwest::Client::new(),
-            options: opts,
-        }
-    }
-
-    pub async fn ingest(&self, event: &Event) {
-        let json = serde_json::to_vec(event).unwrap();
-
-        let response = self
-            .client
-            .post(format!("http://127.0.0.1:{}/{V1_INGEST_PATH}", self.port))
-            .header(CONTENT_TYPE, "application/json")
-            .body(json)
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::CREATED);
-    }
-
-    pub async fn query(&self, namespace: &str, sql: &str, format: QueryFormat) -> String {
-        let query = InboundQuery {
-            namespace: namespace.to_string(),
-            sql: sql.to_string(),
-        };
-
-        let json = serde_json::to_vec(&query).unwrap();
-
-        let response = self
-            .client
-            .post(format!("http://127.0.0.1:{}/{V1_QUERY_PATH}", self.port))
-            .header(CONTENT_TYPE, "application/json")
-            .header(LYNX_FORMAT_HEADER, format.as_str())
-            .body(json)
-            .send()
-            .await
-            .unwrap();
-
-        response.text().await.unwrap()
-    }
-}
-
-impl Drop for Lynx {
-    fn drop(&mut self) {
-        self.process.kill().expect("Can kill process on Drop");
-    }
-}
+use helpers::{Lynx, LynxOptions};
 
 #[tokio::test]
 async fn query_after_persist() {
@@ -266,8 +144,8 @@ async fn cli() {
         .assert()
         .success();
 
-    println!("{}", query_output.to_string());
+    println!("{}", query_output);
 
     query_output
-        .stdout(contains(format!("{}", event.name)).and(contains(format!("{}", event.value))));
+        .stdout(contains(event.name.to_string()).and(contains(event.value.to_string())));
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -6,7 +6,7 @@ use assert_cmd::{assert::OutputAssertExt, cargo::CommandCargoExt, output::Output
 use lynx::{
     event::Event,
     query::{InboundQuery, QueryFormat, QueryResponse},
-    server::{V1_INGEST_PATH, V1_QUERY_PATH},
+    server::{Persistence, V1_INGEST_PATH, V1_QUERY_PATH},
     LYNX_FORMAT_HEADER,
 };
 use predicates::{boolean::PredicateBooleanExt, str::contains};
@@ -29,6 +29,7 @@ struct Lynx {
 struct LynxOptions {
     port: Option<u16>,
     max_events: Option<i64>,
+    persist_mode: Option<Persistence>,
 }
 
 impl LynxOptions {
@@ -45,6 +46,11 @@ impl LynxOptions {
         self.port = Some(port);
         self
     }
+
+    pub fn with_persist_mode(mut self, persist_mode: Persistence) -> Self {
+        self.persist_mode = Some(persist_mode);
+        self
+    }
 }
 
 impl Lynx {
@@ -57,6 +63,7 @@ impl Lynx {
         });
 
         let max_events = opts.max_events.unwrap_or(2);
+        let persist_mode = opts.persist_mode.clone().unwrap_or_default();
 
         let process = Command::cargo_bin(env!("CARGO_PKG_NAME"))
             .unwrap()
@@ -64,6 +71,7 @@ impl Lynx {
             .env("LYNX_PORT", port.to_string())
             .env("LYNX_PERSIST_PATH", persist_path.path())
             .env("LYNX_PERSIST_EVENTS", max_events.to_string())
+            .env("LYNX_PERSIST_MODE", persist_mode.as_str())
             .spawn()
             .expect("Can run lynx");
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -146,6 +146,5 @@ async fn cli() {
 
     println!("{}", query_output);
 
-    query_output
-        .stdout(contains(event.name.to_string()).and(contains(event.value.to_string())));
+    query_output.stdout(contains(event.name.to_string()).and(contains(event.value.to_string())));
 }

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,4 +1,133 @@
-use lynx::event::Event;
+#![allow(dead_code)]
+
+use std::{process::Command, time::Duration};
+
+use assert_cmd::cargo::CommandCargoExt;
+use rand::Rng;
+use reqwest::{header::CONTENT_TYPE, StatusCode};
+use tempfile::TempDir;
+
+use lynx::{
+    event::Event,
+    query::{InboundQuery, QueryFormat},
+    server::{Persistence, V1_INGEST_PATH, V1_QUERY_PATH},
+    LYNX_FORMAT_HEADER,
+};
+
+pub struct Lynx {
+    pub process: std::process::Child,
+    pub client: reqwest::Client,
+    pub port: u16,
+    pub persist_path: TempDir,
+    /// Options that the test instance of lynx was configured with.
+    pub options: LynxOptions,
+}
+
+#[derive(Default)]
+pub struct LynxOptions {
+    pub port: Option<u16>,
+    pub max_events: Option<i64>,
+    pub persist_mode: Option<Persistence>,
+}
+
+impl LynxOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_max_events(mut self, max_events: i64) -> Self {
+        self.max_events = Some(max_events);
+        self
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub fn with_persist_mode(mut self, persist_mode: Persistence) -> Self {
+        self.persist_mode = Some(persist_mode);
+        self
+    }
+}
+
+impl Lynx {
+    pub fn new(opts: LynxOptions) -> Self {
+        let persist_path = TempDir::new().unwrap();
+
+        let port = opts.port.unwrap_or_else(|| {
+            let mut rand = rand::thread_rng();
+            rand.gen_range(1024..=65535) // User port range
+        });
+
+        let max_events = opts.max_events.unwrap_or(2);
+        let persist_mode = opts.persist_mode.clone().unwrap_or_default();
+
+        let process = Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .arg("server")
+            .env("LYNX_PORT", port.to_string())
+            .env("LYNX_PERSIST_PATH", persist_path.path())
+            .env("LYNX_PERSIST_EVENTS", max_events.to_string())
+            .env("LYNX_PERSIST_MODE", persist_mode.as_str())
+            .spawn()
+            .expect("Can run lynx");
+
+        // Arbitrary sleep to enforce server startup period
+        // TODO: this could be flakey
+        std::thread::sleep(Duration::from_secs(2));
+
+        Self {
+            port,
+            persist_path,
+            process,
+            client: reqwest::Client::new(),
+            options: opts,
+        }
+    }
+
+    pub async fn ingest(&self, event: &Event) {
+        let json = serde_json::to_vec(event).unwrap();
+
+        let response = self
+            .client
+            .post(format!("http://127.0.0.1:{}/{V1_INGEST_PATH}", self.port))
+            .header(CONTENT_TYPE, "application/json")
+            .body(json)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    pub async fn query(&self, namespace: &str, sql: &str, format: QueryFormat) -> String {
+        let query = InboundQuery {
+            namespace: namespace.to_string(),
+            sql: sql.to_string(),
+        };
+
+        let json = serde_json::to_vec(&query).unwrap();
+
+        let response = self
+            .client
+            .post(format!("http://127.0.0.1:{}/{V1_QUERY_PATH}", self.port))
+            .header(CONTENT_TYPE, "application/json")
+            .header(LYNX_FORMAT_HEADER, format.as_str())
+            .body(json)
+            .send()
+            .await
+            .unwrap();
+
+        response.text().await.unwrap()
+    }
+}
+
+impl Drop for Lynx {
+    fn drop(&mut self) {
+        self.process.kill().expect("Can kill process on Drop");
+    }
+}
 
 pub fn arbitrary_event() -> Event {
     Event {


### PR DESCRIPTION
Closes https://github.com/jdockerty/lynx/issues/11

Utilises the `object_store` crate to enable writing to a remote object store. This has the knock-on effect that the local filesystem can also be treated as something which satisfies the `ObjectStore` trait.
