### PR TITLE
refactor: server healthy in tests

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -12,6 +12,7 @@ use helpers::{Lynx, LynxOptions};
 #[tokio::test]
 async fn query_after_persist() {
     let lynx = Lynx::new(LynxOptions::new());
+    lynx.ensure_healthy().await;
 
     let event = helpers::arbitrary_event();
     lynx.ingest(&event).await;
@@ -46,6 +47,7 @@ async fn query_after_persist() {
 #[tokio::test]
 async fn ingest_and_persist_check() {
     let lynx = Lynx::new(LynxOptions::new());
+    lynx.ensure_healthy().await;
 
     let event = helpers::arbitrary_event();
     lynx.ingest(&event).await;
@@ -84,6 +86,7 @@ async fn ingest_and_persist_check() {
 async fn persist_with_increased_counter() {
     let opts = LynxOptions::new().with_max_events(5);
     let lynx = Lynx::new(opts);
+    lynx.ensure_healthy().await;
 
     let event = helpers::arbitrary_event();
     lynx.ingest(&event).await;
@@ -108,6 +111,7 @@ async fn persist_with_increased_counter() {
 #[tokio::test]
 async fn cli() {
     let lynx = Lynx::new(LynxOptions::new().with_max_events(1));
+    lynx.ensure_healthy().await;
 
     let write_input = NamedTempFile::new().unwrap();
     let event = helpers::arbitrary_event();

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -73,10 +73,6 @@ impl Lynx {
             .spawn()
             .expect("Can run lynx");
 
-        // Arbitrary sleep to enforce server startup period
-        // TODO: this could be flakey
-        std::thread::sleep(Duration::from_secs(2));
-
         Self {
             port,
             persist_path,
@@ -84,6 +80,25 @@ impl Lynx {
             client: reqwest::Client::new(),
             options: opts,
         }
+    }
+
+    pub async fn ensure_healthy(&self) {
+        tokio::time::timeout(Duration::from_secs(3), async move {
+            let client = reqwest::Client::new();
+            loop {
+                if client
+                    .get(format!("http://127.0.0.1:{}/health", self.port))
+                    .send()
+                    .await
+                    .is_ok()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .expect("Server is healthy");
     }
 
     pub async fn ingest(&self, event: &Event) {


### PR DESCRIPTION
Swaps the arbitrary sleep to ensure that the server has started for a `Lynx::ensure_healthy` function which hits the `/health` endpoint which will be available when the server has started.

If the server is not considered healthy after 3 seconds this forces a panic, i.e. failing a test.
