### PR TITLE
feat: ingest batched writes for json arrays

### DIFF
--- a/src/persist.rs
+++ b/src/persist.rs
@@ -211,11 +211,10 @@ mod test {
             metadata: serde_json::Value::Null,
         };
         tx.send(event.clone()).await.unwrap();
-        assert_eq!(
-            tokio::fs::try_exists(temp_dir.path().join("lynx").join("my_org_2"))
+        assert!(
+            !tokio::fs::try_exists(temp_dir.path().join("lynx").join("my_org_2"))
                 .await
                 .unwrap(),
-            false,
             "No persistence expected for 'my_org_2', only 1 event was sent when 2 are required"
         );
 
@@ -244,11 +243,10 @@ mod test {
             panic!("Persistence did not occur");
         }
 
-        assert_eq!(
-            tokio::fs::try_exists(temp_dir.path().join("lynx").join("my_org_2"))
+        assert!(
+            !tokio::fs::try_exists(temp_dir.path().join("lynx").join("my_org_2"))
                 .await
                 .unwrap(),
-            false,
             "Persistence for 'my_org_2' still should not occurr"
         );
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -91,11 +91,27 @@ async fn health() -> &'static str {
     "OK"
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+// Incoming events are JSON blobs which do not indicate their "type", except by
+// being an array in batch and a singular JSON structure for 1 event.
+#[serde(untagged)]
+enum IngestType {
+    Single(Event),
+    Batch(Vec<Event>),
+}
+
 async fn ingest(
     State(mut state): State<ServerState>,
-    Json(event): Json<Event>,
+    Json(ingest_type): Json<IngestType>,
 ) -> impl IntoResponse {
-    state.ingest.handle_event(event).await;
+    match ingest_type {
+        IngestType::Single(event) => state.ingest.handle_event(event).await,
+        IngestType::Batch(events) => {
+            for event in events {
+                state.ingest.handle_event(event).await;
+            }
+        }
+    }
     StatusCode::CREATED
 }
 

--- a/testdata/events.json
+++ b/testdata/events.json
@@ -1,0 +1,18 @@
+[
+    {
+        "namespace": "my_org_1",
+        "name": "unit_temp",
+        "timestamp": 1734557462688037,
+        "precision": "microsecond",
+        "value": 19,
+        "metadata": {}
+    },
+    {
+        "namespace": "my_org_1",
+        "name": "cpu_usage",
+        "timestamp": 1734557462689129,
+        "precision": "microsecond",
+        "value": 81,
+        "metadata": {}
+    }
+]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -109,6 +109,49 @@ async fn persist_with_increased_counter() {
 }
 
 #[tokio::test]
+async fn ingest_batched_events() {
+    let lynx = Lynx::new(LynxOptions::new());
+    lynx.ensure_healthy().await;
+
+    let events = vec![
+        helpers::arbitrary_event(),
+        helpers::arbitrary_event(),
+        helpers::arbitrary_event(),
+    ];
+    let namespace = events[0].namespace.clone();
+
+    lynx.ingest_batch(events).await;
+
+    tokio::time::timeout(Duration::from_secs(3), async {
+        let namespace_path = lynx.persist_path.path().join("lynx").join(namespace);
+        loop {
+            match std::fs::read_dir(&namespace_path) {
+                Ok(entries) => {
+                    // Short wait for persistence now that the path exists
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    for entry in entries {
+                        let entry = entry.unwrap();
+                        assert!(
+                            entry.file_name().to_string_lossy().contains(".parquet"),
+                            "Parquet files are persisted"
+                        );
+                        assert!(
+                            entry.metadata().unwrap().len() > 0,
+                            "Persisted file should not be blank"
+                        );
+                    }
+                    break;
+                }
+                Err(e) => eprintln!("Unable to read {}, retrying: {e}", namespace_path.display()),
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .expect("Persist event did not occur");
+}
+
+#[tokio::test]
 async fn cli() {
     let lynx = Lynx::new(LynxOptions::new().with_max_events(1));
     lynx.ensure_healthy().await;

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -116,6 +116,21 @@ impl Lynx {
         assert_eq!(response.status(), StatusCode::CREATED);
     }
 
+    pub async fn ingest_batch(&self, events: Vec<Event>) {
+        let json = serde_json::to_vec(&events).unwrap();
+
+        let response = self
+            .client
+            .post(format!("http://127.0.0.1:{}/{V1_INGEST_PATH}", self.port))
+            .header(CONTENT_TYPE, "application/json")
+            .body(json)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
     pub async fn query(&self, namespace: &str, sql: &str, format: QueryFormat) -> String {
         let query = InboundQuery {
             namespace: namespace.to_string(),


### PR DESCRIPTION
Closes https://github.com/jdockerty/lynx/issues/17

This introduces a new `IngestType` so that we can distinguish between a single and batched write, dependent on a JSON array being sent.


Ref: https://serde.rs/enum-representations.html#untagged
