### PR TITLE
feat: include tables in hierarchy

### DIFF
--- a/src/persist.rs
+++ b/src/persist.rs
@@ -105,7 +105,9 @@ pub async fn run_persist_actor(mut actor: PersistActor) {
             let now = chrono::Utc::now().timestamp_micros();
             let filename = format!("lynx-{now}.parquet");
             let namespace = &event.namespace;
-            let path = object_store::path::Path::from(format!("lynx/{namespace}/{filename}"));
+            let event_name = &event.name;
+            let path =
+                object_store::path::Path::from(format!("lynx/{namespace}/{event_name}/{filename}"));
             eprintln!("Persisting to {path}");
 
             let payload = PutPayload::from_bytes(v.into());

--- a/src/query.rs
+++ b/src/query.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use datafusion::datasource::{file_format::parquet::ParquetFormat, listing::ListingOptions};
-use datafusion::functions::string::split_part;
 use datafusion::prelude::SessionContext;
+use datafusion::sql::parser::Statement;
+use datafusion::sql::sqlparser::ast::{SetExpr, TableFactor};
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -80,7 +81,8 @@ pub async fn handle_sql(
                         // `handle_sql` though too.
                         let path = PathBuf::from(namespace_path);
                         let bucket = path.parent().unwrap().parent().unwrap();
-                        let bucket_path = format!("s3://{}/lynx/{namespace}/{table_name}", bucket.display());
+                        let bucket_path =
+                            format!("s3://{}/lynx/{namespace}/{table_name}", bucket.display());
                         ctx.register_object_store(
                             &reqwest::Url::parse(&bucket_path).unwrap(),
                             Arc::clone(&object_store),
@@ -119,14 +121,33 @@ pub async fn handle_sql(
 /// Temporary hack to parse table names.
 ///
 /// This is very much a hack by assuming the query is simple.
-pub(crate) fn parse_table_name_hack(sql: &str) -> String {
-    let sanitised = sql.to_lowercase();
-    sanitised
-        .split_once("from")
-        .expect("Only simple queries are supported currently")
-        .1
-        .trim()
-        .to_string()
+pub(crate) fn parse_table_name_hack(sql: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let statements = datafusion::sql::parser::DFParser::parse_sql(sql)?;
+    let statement = statements
+        .front()
+        .expect("Sub-queries are not supported at this time");
+
+    match statement {
+        Statement::Statement(stmt) => match *stmt.clone() {
+            datafusion::sql::sqlparser::ast::Statement::Query(query) => match *query.body {
+                SetExpr::Select(select) => {
+                    let table = select
+                        .from
+                        .iter()
+                        .take(1)
+                        .next()
+                        .expect("Query should be sent");
+                    match &table.relation {
+                        TableFactor::Table { name, .. } => Ok(name.to_string().to_lowercase()),
+                        _ => todo!(),
+                    }
+                }
+                _ => Err("Only simple SELECT queries are supported at this time".into()),
+            },
+            _ => Err("Only simple SELECT queries are supported at this time".into()),
+        },
+        _ => Err("Only simple SELECT queries are supported at this time".into()),
+    }
 }
 
 #[cfg(test)]
@@ -148,7 +169,11 @@ mod test {
         let persist_path = TempDir::new().unwrap();
         let namespace = "my_namespace";
         let table_name = "my_table";
-        let namespace_path = &persist_path.path().join("lynx").join(namespace).join(table_name);
+        let namespace_path = &persist_path
+            .path()
+            .join("lynx")
+            .join(namespace)
+            .join(table_name);
 
         let files = Arc::new(Mutex::new(HashMap::new()));
         let ctx = SessionContext::new();
@@ -198,12 +223,23 @@ mod test {
     #[test]
     fn table_name_hack() {
         assert_eq!(
-            parse_table_name_hack("SELECT (id, name) from users"),
+            parse_table_name_hack("SELECT * from myTable").unwrap(),
+            "mytable".to_string()
+        );
+        assert_eq!(
+            parse_table_name_hack("SELECT (id, name) from users").unwrap(),
             "users".to_string()
         );
         assert_eq!(
-            parse_table_name_hack("SELECT * from TEST_TABLE"),
+            parse_table_name_hack("SELECT * from TEST_TABLE").unwrap(),
             "test_table".to_string()
+        );
+        assert_eq!(
+            parse_table_name_hack(
+                "SELECT user_name from all_users WHERE name = 'John' AND location = 'UK'"
+            )
+            .unwrap(),
+            "all_users".to_string()
         );
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use datafusion::datasource::{file_format::parquet::ParquetFormat, listing::ListingOptions};
+use datafusion::functions::string::split_part;
 use datafusion::prelude::SessionContext;
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
@@ -60,6 +61,7 @@ impl From<&str> for QueryFormat {
 pub async fn handle_sql(
     files: Arc<Mutex<HashMap<String, SessionContext>>>,
     namespace: &str,
+    table_name: &str,
     sql: String,
     namespace_path: &str,
     object_store: Arc<dyn ObjectStore>,
@@ -78,14 +80,14 @@ pub async fn handle_sql(
                         // `handle_sql` though too.
                         let path = PathBuf::from(namespace_path);
                         let bucket = path.parent().unwrap().parent().unwrap();
-                        let bucket_path = format!("s3://{}/lynx/", bucket.display());
+                        let bucket_path = format!("s3://{}/lynx/{namespace}/{table_name}", bucket.display());
                         ctx.register_object_store(
                             &reqwest::Url::parse(&bucket_path).unwrap(),
                             Arc::clone(&object_store),
                         );
                         ctx.register_listing_table(
                             namespace,
-                            format!("{bucket_path}{namespace}/"),
+                            format!("{bucket_path}{namespace}/{table_name}/"),
                             list_opts.clone(),
                             None,
                             None,
@@ -95,7 +97,7 @@ pub async fn handle_sql(
                     }
                     Persistence::Local => {
                         ctx.register_listing_table(
-                            namespace,
+                            table_name,
                             namespace_path,
                             list_opts.clone(),
                             None,
@@ -114,6 +116,19 @@ pub async fn handle_sql(
     }
 }
 
+/// Temporary hack to parse table names.
+///
+/// This is very much a hack by assuming the query is simple.
+pub(crate) fn parse_table_name_hack(sql: &str) -> String {
+    let sanitised = sql.to_lowercase();
+    sanitised
+        .split_once("from")
+        .expect("Only simple queries are supported currently")
+        .1
+        .trim()
+        .to_string()
+}
+
 #[cfg(test)]
 mod test {
     use std::{collections::HashMap, sync::Arc};
@@ -126,13 +141,14 @@ mod test {
 
     use crate::server::Persistence;
 
-    use super::handle_sql;
+    use super::{handle_sql, parse_table_name_hack};
 
     #[tokio::test]
     async fn query() {
         let persist_path = TempDir::new().unwrap();
         let namespace = "my_namespace";
-        let namespace_path = &persist_path.path().join("lynx").join(namespace);
+        let table_name = "my_table";
+        let namespace_path = &persist_path.path().join("lynx").join(namespace).join(table_name);
 
         let files = Arc::new(Mutex::new(HashMap::new()));
         let ctx = SessionContext::new();
@@ -155,13 +171,11 @@ mod test {
 
         files.lock().await.insert(namespace.to_string(), ctx);
 
-        for f in std::fs::read_dir(namespace_path).unwrap() {
-            println!("{f:?}");
-        }
         let batches = handle_sql(
             files,
             namespace,
-            format!("SELECT * FROM {namespace}"),
+            table_name,
+            format!("SELECT * FROM {table_name}"),
             &namespace_path.to_string_lossy(),
             Arc::new(object_store::memory::InMemory::new()),
             Persistence::Local,
@@ -179,5 +193,17 @@ mod test {
             "| 3   |",
             "+-----+",
         ], &batches);
+    }
+
+    #[test]
+    fn table_name_hack() {
+        assert_eq!(
+            parse_table_name_hack("SELECT (id, name) from users"),
+            "users".to_string()
+        );
+        assert_eq!(
+            parse_table_name_hack("SELECT * from TEST_TABLE"),
+            "test_table".to_string()
+        );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,8 +163,16 @@ async fn query(
     State(state): State<ServerState>,
     Json(payload): Json<InboundQuery>,
 ) -> (StatusCode, impl IntoResponse) {
-
-    let table_name = parse_table_name_hack(&payload.sql);
+    let table_name = match parse_table_name_hack(&payload.sql) {
+        Ok(table_name) => table_name,
+        Err(e) => {
+            eprintln!("query error: {e}");
+            return (
+                StatusCode::BAD_REQUEST,
+                "An unsupported query was provided".to_string(),
+            );
+        }
+    };
     let namespace_path = &format!(
         "{}/{}/{}",
         state.persist_path.to_string_lossy(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::query::{InboundQuery, QueryFormat};
+use crate::query::{parse_table_name_hack, InboundQuery, QueryFormat};
 use crate::{event::Event, persist::PersistHandle, query::handle_sql};
 use arrow::util::pretty::pretty_format_batches;
 use axum::http::HeaderMap;
@@ -163,14 +163,18 @@ async fn query(
     State(state): State<ServerState>,
     Json(payload): Json<InboundQuery>,
 ) -> (StatusCode, impl IntoResponse) {
+
+    let table_name = parse_table_name_hack(&payload.sql);
     let namespace_path = &format!(
-        "{}/{}",
+        "{}/{}/{}",
         state.persist_path.to_string_lossy(),
-        &payload.namespace
+        &payload.namespace,
+        table_name,
     );
     if let Some(record_batches) = handle_sql(
         state.files,
         &payload.namespace,
+        &table_name,
         payload.sql,
         namespace_path,
         state.object_store,


### PR DESCRIPTION
Helps with https://github.com/jdockerty/lynx/issues/7

Prior to this when data was ingested the namespace and table were conflated.

This meant that data was written into a singular namespace, but used the concept of a "table" to read from. This was incorrect as it meant `datafusion` would be reading an entire namespace worth of parquet files, regardless of the `... FROM my_table` being specified. This had a knock-on effect because the namespace and `FROM X` must be the same.

Now, there is a hierarchical structure for persists. A table resides under a namespace. This adds a small hack for an SQL query which assumes that simple queries are sent with `FROM table_name` values. For now, this is okay.
