### PR TITLE
fix: e2e tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+  push:
+    branches: ["main"]
+    tags:
+      - v*.*.*
+  pull_request:
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
+      - uses: arduino/setup-protoc@v3
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Lint
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Check
+        run: cargo check
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2
-      - uses: arduino/setup-protoc@v3
       - name: Format
         run: cargo fmt --all --check
       - name: Lint

--- a/src/bin/lynx.rs
+++ b/src/bin/lynx.rs
@@ -146,6 +146,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Persistence::Local => persist_path.join("lynx"),
                 Persistence::S3 => format!("{}/lynx", aws.bucket.unwrap()).into(),
             };
+            eprintln!("Persist mode: {}", persist_mode.as_str());
+            eprintln!("Persist path: {}", persist_path.display());
 
             let config = ServerRunConfig::new(
                 &host,

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -43,6 +43,7 @@ pub struct PersistActor {
     event_receiver: Receiver<Event>,
     events: HashMap<String, Vec<Event>>,
     files: Arc<Mutex<HashMap<String, SessionContext>>>,
+    #[allow(dead_code)]
     persist_path: PathBuf,
     object_store: Arc<dyn ObjectStore>,
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -23,7 +23,7 @@ async fn query_after_persist() {
             let response = lynx
                 .query(
                     &event.namespace,
-                    &format!("SELECT * FROM {}", event.namespace),
+                    &format!("SELECT * FROM {}", event.name),
                     QueryFormat::Json,
                 )
                 .await;
@@ -54,7 +54,12 @@ async fn ingest_and_persist_check() {
     lynx.ingest(&event).await;
 
     tokio::time::timeout(Duration::from_secs(3), async {
-        let namespace_path = lynx.persist_path.path().join("lynx").join(event.namespace);
+        let namespace_path = lynx
+            .persist_path
+            .path()
+            .join("lynx")
+            .join(event.namespace)
+            .join(event.name);
         loop {
             match std::fs::read_dir(&namespace_path) {
                 Ok(entries) => {
@@ -92,7 +97,12 @@ async fn persist_with_increased_counter() {
     lynx.ingest(&event).await;
     lynx.ingest(&event).await;
 
-    let namespace_path = lynx.persist_path.path().join("lynx").join(&event.namespace);
+    let namespace_path = lynx
+        .persist_path
+        .path()
+        .join("lynx")
+        .join(&event.namespace)
+        .join(&event.name);
     assert!(
         !std::fs::exists(&namespace_path).unwrap(),
         "Persist should not have happened yet"
@@ -119,11 +129,17 @@ async fn ingest_batched_events() {
         helpers::arbitrary_event(),
     ];
     let namespace = events[0].namespace.clone();
+    let event_name = events[0].name.clone();
 
     lynx.ingest_batch(events).await;
 
-    tokio::time::timeout(Duration::from_secs(3), async {
-        let namespace_path = lynx.persist_path.path().join("lynx").join(namespace);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let namespace_path = lynx
+            .persist_path
+            .path()
+            .join("lynx")
+            .join(namespace)
+            .join(event_name);
         loop {
             match std::fs::read_dir(&namespace_path) {
                 Ok(entries) => {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -163,7 +163,7 @@ async fn cli() {
     let query_input = NamedTempFile::new().unwrap();
     let query = InboundQuery {
         namespace: event.namespace.clone(),
-        sql: format!("SELECT * from {}", event.namespace),
+        sql: format!("SELECT * from {}", event.name),
     };
     serde_json::to_writer(&query_input, &query).unwrap();
 


### PR DESCRIPTION
After https://github.com/jdockerty/lynx/pull/23, these were broken from not including the event name in the persist/query tests, as the directory structure was further nested 1 level down.

This includes some basic CI scaffolding too, such that it is more obvious when things break again.