### PR TITLE
feat: data model

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use axum::{
     Router,
     extract::State,
     http::StatusCode,
-    response::Json,
+    response::{IntoResponse, Json},
     routing::{get, post},
 };
 use clap::Parser;
@@ -37,14 +37,16 @@ struct AppState {
 
 #[derive(Deserialize)]
 struct WriteRequest {
-    // TODO
-    data: serde_json::Value,
+    namespace: String,
+    value: String,
+    tags: Vec<(String, TagValue)>,
+    timestamp: u64,
 }
 
-#[derive(Serialize)]
-struct WriteResponse {
-    success: bool,
-    message: String,
+#[derive(Deserialize)]
+enum TagValue {
+    String,
+    Int,
 }
 
 #[derive(Deserialize)]
@@ -64,14 +66,11 @@ async fn health() -> StatusCode {
 }
 
 async fn write_handler(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Json(payload): Json<WriteRequest>,
-) -> Result<Json<WriteResponse>, StatusCode> {
+) -> impl IntoResponse {
     // TODO
-    Ok(Json(WriteResponse {
-        success: true,
-        message: format!("Write request received: {:?}", payload.data),
-    }))
+    StatusCode::OK
 }
 
 async fn query_handler(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,13 @@ use axum::{
 };
 use clap::Parser;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+    io::{Read, Write},
+    sync::Arc,
+};
 use std::{net::SocketAddr, path::PathBuf};
 
-use crate::wal::Wal;
+use crate::wal::{Wal, WriteRequest};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -33,20 +36,6 @@ struct Args {
 
 struct AppState {
     wal: Wal,
-}
-
-#[derive(Deserialize)]
-struct WriteRequest {
-    namespace: String,
-    value: String,
-    tags: Vec<(String, TagValue)>,
-    timestamp: u64,
-}
-
-#[derive(Deserialize)]
-enum TagValue {
-    String,
-    Int,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Update the data model for a `WriteRequest`, including a `to_bytes` and `from_reader` scaffolding to aid follow-up wiring and testing.