### PR TITLE
feat: store incoming writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +66,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -117,16 +132,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -175,6 +219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +239,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fnv"
@@ -340,6 +396,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +430,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -383,6 +473,7 @@ name = "lynx"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "clap",
  "serde",
  "serde_json",
@@ -417,6 +508,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -519,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +701,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -761,10 +873,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.48.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = "0.4.42"
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/src/lynx.rs
+++ b/src/lynx.rs
@@ -1,0 +1,91 @@
+use std::{
+    collections::{BTreeMap, btree_map::Entry},
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use crate::wal::{TagValue, Wal, WriteRequest};
+
+/// Time format string for daily partition keys.
+///
+/// This means that data is partitioned by day at all times currently.
+const DAILY_PARTITION: &str = "%Y-%m-%d";
+
+#[derive(Default, Debug)]
+pub struct Measurements {
+    pub timestamps: Vec<u64>,
+    pub tags: Vec<(String, TagValue)>,
+    pub values: Vec<String>,
+}
+
+/// Lynx, an in-memory time-series database with durable writes.
+pub struct Lynx {
+    /// Write-ahead log to provide durable writes for incoming data.
+    ///
+    /// Data MUST be appended to the WAL before making its way into the
+    /// in-memory buffer.
+    wal: Mutex<Wal>,
+    /// In-memory structure which makes the durable writes queryable.
+    buffer: Arc<Mutex<BTreeMap<String, BTreeMap<String, Measurements>>>>,
+}
+
+impl Lynx {
+    /// Create a new Lynx instance with the given WAL configuration.
+    pub fn new(wal_directory: impl AsRef<Path>, max_segment_size: u64) -> Self {
+        Self {
+            wal: Mutex::new(Wal::new(wal_directory, max_segment_size)),
+            buffer: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    fn parse_partition_key(timestamp: i64) -> String {
+        let utc_datetime = chrono::DateTime::from_timestamp_micros(timestamp)
+            .expect("timestamps are currently assumed to be microseconds");
+        utc_datetime.format(DAILY_PARTITION).to_string()
+    }
+
+    /// Write a new request into the database.
+    ///
+    /// This ensures that data is durable before it becomes queryable within
+    /// an in-memory buffer.
+    pub fn write(&self, payload: WriteRequest) -> Result<(), Box<dyn std::error::Error>> {
+        self.wal.lock().unwrap().write(payload.clone())?;
+
+        let mut buffer_guard = self.buffer.lock().unwrap();
+        match buffer_guard.entry(payload.namespace) {
+            Entry::Vacant(vacant) => {
+                let partition_key = Self::parse_partition_key(payload.timestamp as i64);
+                vacant.insert(BTreeMap::from_iter([(
+                    partition_key,
+                    Measurements {
+                        timestamps: vec![payload.timestamp],
+                        tags: payload.tags,
+                        values: vec![payload.value],
+                    },
+                )]));
+            }
+            Entry::Occupied(mut buffer_entry) => {
+                let partitions = buffer_entry.get_mut();
+
+                let partition_key = Self::parse_partition_key(payload.timestamp as i64);
+                match partitions.entry(partition_key) {
+                    Entry::Vacant(init) => {
+                        init.insert(Measurements {
+                            timestamps: vec![payload.timestamp],
+                            tags: payload.tags,
+                            values: vec![payload.value],
+                        });
+                    }
+                    Entry::Occupied(mut buffered_measurements) => {
+                        let buffered_measurements = buffered_measurements.get_mut();
+                        buffered_measurements.timestamps.push(payload.timestamp);
+                        buffered_measurements.tags.extend(payload.tags);
+                        buffered_measurements.values.push(payload.value);
+                    }
+                };
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/src/lynx.rs
+++ b/src/lynx.rs
@@ -89,3 +89,101 @@ impl Lynx {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_multiple_requests_same_namespace() {
+        let dir = TempDir::new().unwrap();
+        let lynx = Lynx::new(dir.path(), 1024 * 1024);
+
+        let request1 = WriteRequest {
+            namespace: "metrics".to_string(),
+            value: "100".to_string(),
+            tags: vec![("host".to_string(), TagValue::String("server1".to_string()))],
+            timestamp: 1_700_000_000_000_000, // 2023-11-14
+        };
+
+        let request2 = WriteRequest {
+            namespace: "metrics".to_string(),
+            value: "200".to_string(),
+            tags: vec![("host".to_string(), TagValue::String("server2".to_string()))],
+            timestamp: 1_700_000_001_000_000, // Same day
+        };
+
+        lynx.write(request1).unwrap();
+        lynx.write(request2).unwrap();
+
+        let buffer = lynx.buffer.lock().unwrap();
+        let partitions = buffer.get("metrics").unwrap();
+        let measurements = partitions.get("2023-11-14").unwrap();
+
+        assert_eq!(measurements.timestamps.len(), 2);
+        assert_eq!(measurements.values, vec!["100", "200"]);
+        assert_eq!(measurements.tags.len(), 2);
+    }
+
+    #[test]
+    fn write_multiple_namespaces() {
+        let dir = TempDir::new().unwrap();
+        let lynx = Lynx::new(dir.path(), 1024 * 1024);
+
+        let request1 = WriteRequest {
+            namespace: "cpu".to_string(),
+            value: "80".to_string(),
+            tags: vec![],
+            timestamp: 1_700_000_000_000_000,
+        };
+
+        let request2 = WriteRequest {
+            namespace: "memory".to_string(),
+            value: "4096".to_string(),
+            tags: vec![],
+            timestamp: 1_700_000_000_000_000,
+        };
+
+        lynx.write(request1).unwrap();
+        lynx.write(request2).unwrap();
+
+        let buffer = lynx.buffer.lock().unwrap();
+        assert_eq!(buffer.len(), 2);
+        assert!(buffer.contains_key("cpu"));
+        assert!(buffer.contains_key("memory"));
+    }
+
+    #[test]
+    fn partition_by_day() {
+        let dir = TempDir::new().unwrap();
+        let lynx = Lynx::new(dir.path(), 1024 * 1024);
+
+        let request1 = WriteRequest {
+            namespace: "events".to_string(),
+            value: "event1".to_string(),
+            tags: vec![],
+            timestamp: 1_700_000_000_000_000, // 2023-11-14
+        };
+
+        let request2 = WriteRequest {
+            namespace: "events".to_string(),
+            value: "event2".to_string(),
+            tags: vec![],
+            timestamp: 1_700_086_400_000_000, // 2023-11-15
+        };
+
+        lynx.write(request1).unwrap();
+        lynx.write(request2).unwrap();
+
+        let buffer = lynx.buffer.lock().unwrap();
+        let partitions = buffer.get("events").unwrap();
+
+        assert_eq!(partitions.len(), 2);
+        assert!(partitions.contains_key("2023-11-14"));
+        assert!(partitions.contains_key("2023-11-15"));
+
+        assert_eq!(partitions.get("2023-11-14").unwrap().values, vec!["event1"]);
+        assert_eq!(partitions.get("2023-11-15").unwrap().values, vec!["event2"]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,18 +25,13 @@ const DAILY_PARTITION: &str = "%Y-%m-%d";
 
 #[derive(Parser, Debug)]
 struct Args {
-    #[arg(short, long, env = "LYNX_HTTP_ADDR", default_value = "127.0.0.1:3000")]
+    #[arg(long, env = "LYNX_HTTP_ADDR", default_value = "127.0.0.1:3000")]
     bind: SocketAddr,
 
-    #[arg(short, long, env = "LYNX_WAL_DIRECTORY")]
+    #[arg(long, env = "LYNX_WAL_DIRECTORY")]
     wal_directory: PathBuf,
 
-    #[arg(
-        short,
-        long,
-        env = "LYNX_WAL_MAX_SEGMENT_SIZE",
-        default_value = "52428800"
-    )]
+    #[arg(long, env = "LYNX_WAL_MAX_SEGMENT_SIZE", default_value = "52428800")]
     wal_max_segment_size: u64,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod lynx;
 mod wal;
 
 use axum::{
@@ -9,19 +10,9 @@ use axum::{
 };
 use clap::Parser;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, btree_map::Entry},
-    sync::{Arc, Mutex},
-};
-use std::{net::SocketAddr, path::PathBuf};
-use wal::TagValue;
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
-use crate::wal::{Wal, WriteRequest};
-
-/// Time format string for daily partition keys.
-///
-/// This means that data is partitioned by day at all times currently.
-const DAILY_PARTITION: &str = "%Y-%m-%d";
+use crate::{lynx::Lynx, wal::WriteRequest};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -36,20 +27,8 @@ struct Args {
 }
 
 struct AppState {
-    /// Write-ahead log to provide durable writes for incoming data.
-    ///
-    /// Data MUST be appended to the WAL before making its way into the
-    /// in-memory buffer.
-    wal: Mutex<Wal>,
-    /// In-memory structure which makes the durable writes queryable.
-    buffer: Arc<Mutex<BTreeMap<String, BTreeMap<String, Measurements>>>>,
-}
-
-#[derive(Default, Debug)]
-struct Measurements {
-    timestamps: Vec<u64>,
-    tags: Vec<(String, TagValue)>,
-    values: Vec<String>,
+    /// An in-memory, durable, time-series database.
+    lynx: Lynx,
 }
 
 #[derive(Deserialize)]
@@ -72,53 +51,13 @@ async fn write_handler(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<WriteRequest>,
 ) -> impl IntoResponse {
-    match state.wal.lock().unwrap().write(payload.clone()) {
-        Ok(_) => {}
+    match state.lynx.write(payload) {
+        Ok(_) => StatusCode::OK,
         Err(e) => {
             eprintln!("{e:?}");
-            return StatusCode::INTERNAL_SERVER_ERROR;
+            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
-    let mut buffer_guard = state.buffer.lock().unwrap();
-    match buffer_guard.entry(payload.namespace) {
-        Entry::Vacant(vacant) => {
-            let inbound_time = chrono::DateTime::from_timestamp_micros(payload.timestamp as i64)
-                .expect("timestamps are currently assumed to be microseconds");
-
-            let partition_key = inbound_time.format(DAILY_PARTITION);
-            vacant.insert(BTreeMap::from_iter([(
-                partition_key.to_string(),
-                Measurements {
-                    timestamps: vec![payload.timestamp],
-                    tags: payload.tags,
-                    values: vec![payload.value],
-                },
-            )]));
-        }
-        Entry::Occupied(mut buffer_entry) => {
-            let partitions = buffer_entry.get_mut();
-
-            let inbound_time = chrono::DateTime::from_timestamp_micros(payload.timestamp as i64)
-                .expect("timestamps are currently assumed to be microseconds");
-            let partition_key = inbound_time.format(DAILY_PARTITION);
-            match partitions.entry(partition_key.to_string()) {
-                Entry::Vacant(init) => {
-                    init.insert(Measurements {
-                        timestamps: vec![payload.timestamp],
-                        tags: payload.tags,
-                        values: vec![payload.value],
-                    });
-                }
-                Entry::Occupied(mut buffered_measurements) => {
-                    let buffered_measurements = buffered_measurements.get_mut();
-                    buffered_measurements.timestamps.push(payload.timestamp);
-                    buffered_measurements.tags.extend(payload.tags);
-                    buffered_measurements.values.push(payload.value);
-                }
-            };
-        }
-    };
-    StatusCode::OK
 }
 
 async fn query_handler(
@@ -139,8 +78,7 @@ async fn main() {
     let args = Args::parse();
 
     let state = Arc::new(AppState {
-        wal: Mutex::new(Wal::new(&args.wal_directory, args.wal_max_segment_size)),
-        buffer: Arc::new(Mutex::new(BTreeMap::new())),
+        lynx: Lynx::new(&args.wal_directory, args.wal_max_segment_size),
     });
 
     let app = Router::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,12 @@ struct Args {
 }
 
 struct AppState {
+    /// Write-ahead log to provide durable writes for incoming data.
+    ///
+    /// Data MUST be appended to the WAL before making its way into the
+    /// in-memory buffer.
     wal: Mutex<Wal>,
+    /// In-memory structure which makes the durable writes queryable.
     buffer: Arc<Mutex<BTreeMap<String, BTreeMap<String, Measurements>>>>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,7 @@ use axum::{
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{
-        BTreeMap,
-        btree_map::{self, Entry},
-    },
+    collections::{BTreeMap, btree_map::Entry},
     sync::{Arc, Mutex},
 };
 use std::{net::SocketAddr, path::PathBuf};
@@ -79,14 +76,14 @@ async fn write_handler(
     }
     let mut buffer_guard = state.buffer.lock().unwrap();
     match buffer_guard.entry(payload.namespace) {
-        Entry::Vacant(vacant_entry) => {
-            vacant_entry.insert(Measurements::default());
+        Entry::Vacant(vacant) => {
+            vacant.insert(Measurements::default());
         }
-        Entry::Occupied(mut occupied_entry) => {
-            let m = occupied_entry.get_mut();
-            m.timestamps.push(payload.timestamp);
-            m.tags.extend(payload.tags);
-            m.values.push(payload.value);
+        Entry::Occupied(mut buffer_entry) => {
+            let buffered_measurements = buffer_entry.get_mut();
+            buffered_measurements.timestamps.push(payload.timestamp);
+            buffered_measurements.tags.extend(payload.tags);
+            buffered_measurements.values.push(payload.value);
         }
     };
     StatusCode::OK

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -12,10 +12,10 @@ const WAL_HEADER: &str = "LYNX1";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct WriteRequest {
-    namespace: String,
-    value: String,
-    tags: Vec<(String, TagValue)>,
-    timestamp: u64,
+    pub namespace: String,
+    pub value: String,
+    pub tags: Vec<(String, TagValue)>,
+    pub timestamp: u64,
 }
 
 impl WriteRequest {
@@ -130,7 +130,7 @@ impl WriteRequest {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-enum TagValue {
+pub enum TagValue {
     String(String),
     Number(u64),
 }

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -129,7 +129,7 @@ impl WriteRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TagValue {
     String(String),
     Number(u64),

--- a/testdata/write.json
+++ b/testdata/write.json
@@ -1,0 +1,6 @@
+{
+  "namespace": "factory_temp",
+  "value": "50",
+  "tags": [],
+  "timestamp": 1761318000019000
+}


### PR DESCRIPTION
Ensure that writes are made during by appending them to the WAL and inserting them into the in-memory buffer.

The buffer is partitioned by time. A `PartitionKey` is derived from the incoming timestamp to produce a daily[^1] partition value.

[^1]: This is currently strictly enforced, but may change later.