### PR TITLE
feat: parse table from query

### DIFF
--- a/src/lynx.rs
+++ b/src/lynx.rs
@@ -220,8 +220,8 @@ fn parse_table_name(sql: &str) -> Result<String, Box<dyn std::error::Error>> {
     let dialect = GenericDialect {};
     let mut ast = Parser::new(&dialect).try_with_sql(sql)?;
 
-    for a in ast.parse_select()?.from {
-        match a.relation {
+    if let Some(factor) = ast.parse_select()?.from.into_iter().next() {
+        match factor.relation {
             datafusion::sql::sqlparser::ast::TableFactor::Table { name, .. } => {
                 return Ok(name.to_string());
             }

--- a/src/lynx.rs
+++ b/src/lynx.rs
@@ -216,6 +216,10 @@ impl Lynx {
     }
 }
 
+/// Parse the table name out of simple 'SELECT ... FROM <table_name>' style queries.
+///
+/// # Note
+/// This does NOT currently handle complex nested queries.
 fn parse_table_name(sql: &str) -> Result<String, Box<dyn std::error::Error>> {
     let dialect = GenericDialect {};
     let mut ast = Parser::new(&dialect).try_with_sql(sql)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,6 @@ struct AppState {
 #[derive(Deserialize)]
 struct QueryRequest {
     namespace: String,
-    table: String,
     query: String,
 }
 
@@ -68,7 +67,7 @@ async fn query_handler(
 ) -> impl IntoResponse {
     let result = state
         .lynx
-        .query(payload.namespace, payload.table, payload.query)
+        .query(payload.namespace, payload.query)
         .await
         .unwrap();
     result.map(|b| print_batches(&b));

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -30,6 +30,11 @@ impl WriteRequest {
         data.write_all(&namespace_len).unwrap();
         data.write_all(&namespace_data).unwrap();
 
+        let measurement_data = self.measurement.as_bytes();
+        let measurement_len = namespace_data.len().to_be_bytes();
+        data.write_all(&measurement_data).unwrap();
+        data.write_all(&measurement_len).unwrap();
+
         let value_data = self.value.as_bytes();
         let value_len = value_data.len().to_be_bytes();
         data.write_all(&value_len).unwrap();

--- a/testdata/query.json
+++ b/testdata/query.json
@@ -1,5 +1,4 @@
 {
   "namespace": "factory",
-  "table": "temp",
-  "query": "SELECT * from temp"
+  "query": "SELECT * FROM temp"
 }


### PR DESCRIPTION
Closes https://github.com/jdockerty/lynx/issues/8

Add the ability to parse simple queries to get the table name out of the `FROM` clause.

This means that there is no need to redundantly specify the table within the query JSON, as it can be inferred from the query itself.

```json
{
  "namespace": "factory",
  "table": "temp", <-- redundant info
  "query": "SELECT * FROM temp"
}
```