### PR TITLE
feat: wal replays

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -106,11 +106,22 @@ impl MemBuffer {
         Ok(())
     }
 
-    pub fn get(
+    /// Return the tables of a [`Namespace`], if any, otherwise [`None`].
+    pub fn tables(
         &self,
         namespace: &Namespace,
     ) -> Option<BTreeMap<Table, BTreeMap<PartitionKey, Measurements>>> {
         self.inner.lock().unwrap().get(&namespace).cloned()
+    }
+
+    /// Return the partitions of a [`Table`] within a [`Namespace`],
+    /// if any, otherwise [`None`].
+    pub fn partitions(
+        &self,
+        namespace: &Namespace,
+        table: &Table,
+    ) -> Option<BTreeMap<PartitionKey, Measurements>> {
+        self.tables(namespace)?.get(table).cloned()
     }
 
     /// Return the total number of namespaces currently held.
@@ -186,13 +197,13 @@ mod test {
         );
 
         let hello_tables = buffer
-            .get(&crate::buffer::Namespace("hello".to_string()))
+            .tables(&crate::buffer::Namespace("hello".to_string()))
             .unwrap();
         let hello_partitions = hello_tables.get(&Table("world".to_string())).unwrap();
         assert_eq!(hello_tables.len(), 1);
         assert_eq!(hello_partitions.len(), 2);
         let another_tables = buffer
-            .get(&crate::buffer::Namespace("another".to_string()))
+            .tables(&crate::buffer::Namespace("another".to_string()))
             .unwrap();
         let another_partitions = another_tables.get(&Table("world".to_string())).unwrap();
         assert_eq!(another_tables.len(), 1);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -111,11 +111,12 @@ impl MemBuffer {
         &self,
         namespace: &Namespace,
     ) -> Option<BTreeMap<Table, BTreeMap<PartitionKey, Measurements>>> {
-        self.inner.lock().unwrap().get(&namespace).cloned()
+        self.inner.lock().unwrap().get(namespace).cloned()
     }
 
     /// Return the partitions of a [`Table`] within a [`Namespace`],
     /// if any, otherwise [`None`].
+    #[allow(dead_code)]
     pub fn partitions(
         &self,
         namespace: &Namespace,

--- a/src/lynx.rs
+++ b/src/lynx.rs
@@ -41,9 +41,11 @@ pub struct Lynx {
 impl Lynx {
     /// Create a new Lynx instance with the given WAL configuration.
     pub fn new(wal_directory: impl AsRef<Path>, max_segment_size: u64) -> Self {
+        let buffer = MemBuffer::new();
+        let next_segment_id = Wal::replay(wal_directory.as_ref(), &buffer).unwrap() + 1;
         Self {
-            wal: Mutex::new(Wal::new(wal_directory, max_segment_size)),
-            buffer: MemBuffer::new(),
+            wal: Mutex::new(Wal::new(wal_directory, next_segment_id, max_segment_size)),
+            buffer,
             query: Arc::new(SessionContext::new()),
         }
     }

--- a/src/lynx.rs
+++ b/src/lynx.rs
@@ -67,7 +67,7 @@ impl Lynx {
         let table_name = parse_table_name(&sql)?;
         // Get a snapshot of the current in-memory data that
         // will be queryable.
-        let tables = self.buffer.get(&Namespace(namespace.clone()));
+        let tables = self.buffer.tables(&Namespace(namespace.clone()));
 
         match tables {
             Some(tables) => {
@@ -201,8 +201,10 @@ mod tests {
         lynx.write(request1.clone()).unwrap();
         lynx.write(request2).unwrap();
 
-        let tables = lynx.buffer.get(&Namespace("metrics".to_string())).unwrap();
-        let partitions = tables.get(&Table("cpu".to_string())).unwrap().clone();
+        let namespace = Namespace("metrics".to_string());
+        let table = Table("cpu".to_string());
+
+        let partitions = lynx.buffer.partitions(&namespace, &table).unwrap();
         assert_eq!(partitions.len(), 1);
 
         // The above requests are part of the same partition, as
@@ -275,8 +277,13 @@ mod tests {
         lynx.write(request1.clone()).unwrap();
         lynx.write(request2.clone()).unwrap();
 
-        let tables = lynx.buffer.get(&Namespace("events".to_string())).unwrap();
-        let partitions = tables.get(&Table("clicks".to_string())).unwrap();
+        let partitions = lynx
+            .buffer
+            .partitions(
+                &Namespace("events".to_string()),
+                &Table("clicks".to_string()),
+            )
+            .unwrap();
 
         assert_eq!(partitions.len(), 2);
 

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -80,7 +80,7 @@ impl WriteRequest {
         let mut namespace_len = [0u8; 8];
         // If we hit an EOF on the namespace, then we can stop reading.
         //
-        // TODO: probably a better way to do this with an WalReader style iterator.
+        // TODO: Elegant way to handle this? This match seems a little clunky
         match r.read_exact(&mut namespace_len) {
             Ok(_) => {
                 let namespace_len = usize::from_be_bytes(namespace_len);


### PR DESCRIPTION
Closes https://github.com/jdockerty/lynx/issues/9

Adds the ability to replay the WAL segment files to ensure data. Prior to this, we would always crash because calling `File::create_new` was hardcoded to segment ID `0`, which would already exist.
