### PR TITLE
feat: query responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,13 +39,6 @@ struct QueryRequest {
     query: String,
 }
 
-#[derive(Serialize)]
-#[expect(dead_code)]
-struct QueryResponse {
-    // TODO
-    results: Vec<serde_json::Value>,
-}
-
 async fn health() -> StatusCode {
     StatusCode::OK
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ async fn main() {
         .route("/api/v1/query", post(query_handler))
         .with_state(state);
 
-    println!("Starting server on {}", args.bind);
+    eprintln!("Starting server on {}", args.bind);
 
     let listener = tokio::net::TcpListener::bind(args.bind)
         .await

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,35 @@
+use datafusion::arrow::{
+    array::RecordBatch, json::ArrayWriter, util::pretty::pretty_format_batches,
+};
+
+/// An adapter which takes input [`RecordBatch`]es and
+/// converts them into a specified response.
+///
+/// Only `table` and `json` are expected currently, as
+/// defined in [`OutputFormat`].
+pub(crate) struct QueryResponseAdapter {
+    batches: Vec<RecordBatch>,
+}
+
+impl QueryResponseAdapter {
+    pub fn new(batches: Vec<RecordBatch>) -> Self {
+        Self { batches }
+    }
+
+    /// Convert the input [`RecordBatch`]es into a JSON array.
+    pub fn into_json(self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let buf = Vec::new();
+        let mut writer = ArrayWriter::new(buf);
+        for batch in &self.batches {
+            writer.write(batch)?;
+        }
+        writer.finish()?;
+        Ok(writer.into_inner())
+    }
+
+    /// Convert the input [`RecordBatch`]es into a pretty-formatted
+    /// table.
+    pub fn into_table(self) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(pretty_format_batches(&self.batches)?.to_string())
+    }
+}

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -207,7 +207,7 @@ impl Wal {
         directory: impl AsRef<Path>,
         buffer: &MemBuffer,
     ) -> Result<u64, Box<dyn std::error::Error>> {
-        Ok(WalReader::new(directory.as_ref(), buffer).read()?)
+        WalReader::new(directory.as_ref(), buffer).read()
     }
 }
 


### PR DESCRIPTION
Populates the query response from the `query_handler` method.

Prior to this, we only printed record batches to stdout, instead of returning them.